### PR TITLE
Remove calculated fields

### DIFF
--- a/roppy-core/src/roppy/core/validate.py
+++ b/roppy-core/src/roppy/core/validate.py
@@ -3,6 +3,7 @@ from pydantic import BeforeValidator, AfterValidator
 from roppy.core.constants import STATES, METHODS, POLY_TYPES
 from roppy.core.solvents import CANONICAL_SOLVENTS, SOLVENT_ALIASES
 from rdkit.Chem.MolStandardize.rdMolStandardize import StandardizeSmiles
+from rdkit.Chem import MolFromSmiles
 
 
 def validate_solvent(solvent: Optional[str]) -> Optional[str]:
@@ -17,6 +18,20 @@ def validate_solvent(solvent: Optional[str]) -> Optional[str]:
 def validate_smiles(smiles: str) -> Optional[str]:
     try:
         return StandardizeSmiles(smiles)
+    except:
+        return None
+
+
+def get_ring_size(smiles: str) -> Optional[int]:
+    """Calculates the size of the largest ring in a molecule given its SMILES."""
+    try:
+        mol = MolFromSmiles(smiles)
+        ring_info = mol.GetRingInfo()
+        n_atoms = mol.GetNumAtoms()
+        max_ring_size = max([ring_info.MinAtomRingSize(i) for i in range(n_atoms)])
+        if max_ring_size == 0:
+            return None
+        return max_ring_size
     except:
         return None
 


### PR DESCRIPTION
Just FYI @Ryan-Reese, I had to remove the calculated fields since these don't get stored in the database automatically. See:
- https://github.com/pydantic/pydantic/issues/8564
- https://github.com/BeanieODM/beanie/issues/933
Instead I made them calculated automatically by the `default_factory`.